### PR TITLE
Upgrade Android Java SDK to match Newer endpoint v3 (#31)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ allprojects {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.doordeck:doordeck-sdk-java:2.0.4'
+    implementation 'com.github.doordeck:doordeck-sdk-java:2.0.5'
     implementation 'com.google.guava:guava:28.0-android'
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@doordeck/react-native-doordeck-sdk",
   "title": "React Native Doordeck Sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "React Native wrapper for the Doordeck SDK.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* Update the Android version

* Update readme

* Update hard copy of Swift library

* Update README.md

* Revert package name

* Update to latest Swift SDK

* Get ready for next

* Update README.md

* Add specific target module

* Update Android version for OkHttp

* Update Android SDK to achieve Multi-device version

* Revert "Update Android SDK to achieve Multi-device version"

This reverts commit 2b229a8fc6b2ac9582af2cc7882d081f4e6d92ce.

* Update Android SDK to achieve Multi-device version

* Update Android SDK due certificate's change

* Upgrade Android Java SDK to match Newer endpoint v3

Co-authored-by: marwan87 <marwan87@users.noreply.github.com>